### PR TITLE
Handle 1xN kernels as 1D

### DIFF
--- a/hls4ml/templates/vivado/nnet_utils/nnet_common.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_common.h
@@ -25,6 +25,7 @@
 // This is a substitute for "ceil(n/(float)d)".
 #define DIV_ROUNDUP(n,d) ((n + d - 1) / d)
 #define MIN(n,d) (n > d ? d : n)
+#define MAX(n,d) (n > d ? n : d)
 
 namespace nnet {
 

--- a/hls4ml/templates/vivado/nnet_utils/nnet_conv_stream.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_conv_stream.h
@@ -173,7 +173,7 @@ void kernel_shift_2d(
 
 template <class data_T, class res_T, typename CONFIG_T>
 void shift_line_buffer(const data_T& in_elem, 
-                    ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[CONFIG_T::filt_height - 1][CONFIG_T::n_chan],
+                    ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[MAX(CONFIG_T::filt_height - 1,1)][CONFIG_T::n_chan],
                     typename data_T::value_type kernel_window[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan]
 ) {
     
@@ -204,7 +204,7 @@ void shift_line_buffer(const data_T& in_elem,
 template<class data_T, class res_T, typename CONFIG_T>
 void compute_output_buffer_2d(
     const data_T& in_elem,
-    ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[CONFIG_T::filt_height - 1][CONFIG_T::n_chan],
+    ap_shift_reg<typename data_T::value_type, CONFIG_T::in_width> line_buffer[MAX(CONFIG_T::filt_height - 1,1)][CONFIG_T::n_chan],
     hls::stream<res_T> &res_stream,
     typename CONFIG_T::weight_t weights[CONFIG_T::kernel_size * CONFIG_T::n_chan * CONFIG_T::n_filt],
     typename CONFIG_T::bias_t biases[CONFIG_T::n_filt]


### PR DESCRIPTION
As we discussed, this uses 1D line buffer function in Conv2D when the kernel is 1xN. Since the `if` check is compile-time constant, there is no penalty in resources and HLS compiler optimizes it away. The rest of the changes are just to make sure the code compiles.